### PR TITLE
chore: fix the allowed versions of postgres

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,13 @@
         "labels": ["package-deps"],
         "commitMessageTopic": "package-deps",
         "matchDatasources": ["docker", "helm", "git-tags"]
+      },
+      {
+        "groupName": "Postgres Package Dependencies",
+        "labels": ["package-deps"],
+        "commitMessageTopic": "package-deps",
+        "matchPackageNames": ["registry.opensource.zalan.do/acid/logical-backup", "registry.opensource.zalan.do/acid/postgres-operator"],
+        "allowedVersions": "/v.+/"
       }
     ]
   }


### PR DESCRIPTION
## Description

This fixes the versions that renovate will choose for the postgres images.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
