### PR TITLE
feat: add wait for PGO package CR readiness

### DIFF
--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -21,6 +21,14 @@ components:
     actions:
       onDeploy:
         after:
+          - description: Validate Postgres Operator Package
+            maxTotalSeconds: 300
+            wait:
+              cluster:
+                kind: Packages
+                name: postgres
+                namespace: postgres
+                condition: "'{.status.phase}'=Ready"
           - description: Postgres Operator to be Healthy
             maxTotalSeconds: 90
             wait:


### PR DESCRIPTION
## Description

Adds a wait action for the PGO package CR. This is consistent with the pattern in uds-core however it runs after the Postgres Operator chart installs (meaning the Postgres Operator chart may still fail waiting on resources like secrets to exist) however this will catch other issues such as failed updates to resources or missing resources the chart doesn't directly depend on like netpols.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
