### PR TITLE
chore: change image refs to support multi arch

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -2,11 +2,11 @@ includes:
   - cleanup: ./tasks/cleanup.yaml
   - dependencies: ./tasks/dependencies.yaml
   - test: ./tasks/test.yaml
-  - create: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.0/tasks/create.yaml
-  - lint: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.0/tasks/lint.yaml
-  - pull: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.0/tasks/pull.yaml
-  - deploy: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.0/tasks/deploy.yaml
-  - setup: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.0/tasks/setup.yaml
+  - create: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.5/tasks/create.yaml
+  - lint: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.5/tasks/lint.yaml
+  - pull: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.5/tasks/pull.yaml
+  - deploy: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.5/tasks/deploy.yaml
+  - setup: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.5/tasks/setup.yaml
 
 tasks:
   - name: default

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -1,6 +1,6 @@
 includes:
-  - create: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.0/tasks/create.yaml
-  - publish: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.0/tasks/publish.yaml
+  - create: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.5/tasks/create.yaml
+  - publish: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.4.5/tasks/publish.yaml
 
 tasks:
   - name: package

--- a/values/upstream-values.yaml
+++ b/values/upstream-values.yaml
@@ -1,9 +1,9 @@
 image:
-  registry: registry.opensource.zalan.do
-  repository: acid/postgres-operator
+  registry: ghcr.io
+  repository: zalando/postgres-operator
 configConnectionPooler:
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-27"
+  connection_pooler_image: "docker.io/bitnami/pgbouncer:1.21.0"
 configLogicalBackup:
-  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.11.0"
+  logical_backup_docker_image: "ghcr.io/zalando/postgres-operator/logical-backup:v1.11.0"
 configGeneral:
   docker_image: "ghcr.io/zalando/spilo-15:3.2-p1"

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -49,8 +49,8 @@ components:
         valuesFiles:
           - ./values/upstream-values.yaml
     images:
-      - registry.opensource.zalan.do/acid/postgres-operator:v1.11.0
-      - registry.opensource.zalan.do/acid/logical-backup:v1.11.0
-      - registry.opensource.zalan.do/acid/pgbouncer:master-27
+      - ghcr.io/zalando/postgres-operator:v1.11.0
+      - ghcr.io/zalando/postgres-operator/logical-backup:v1.11.0
+      - docker.io/bitnami/pgbouncer:1.21.0
       # Docker image that provides PostgreSQL and Patroni bundled together for PostgreSQL HA
       - ghcr.io/zalando/spilo-15:3.2-p1


### PR DESCRIPTION
## Description
The `registry.opensource.zalan.do` registry does not support multi arch images so we are actually packaging the amd64 image for arm64 arch and running the operator on arm fails with `stderr F exec /postgres-operator: exec format error`

This PR changes to zolando's ghcr packages except for `pgbouncer` which was not available there so changed to the bitnami image from docker.io instead. This should get all the images supporting multi arch for upstream.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
