### PR TITLE
fix: netpol selector correction for ingress to pg-cluster

### DIFF
--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -38,9 +38,9 @@ packages:
                   gitlabdb: gitlab.gitlab
                   mattermostdb: mattermost.mattermost
                   sonarqubedb: sonarqube.sonarqube
-                version: "13"
+                version: "14"
                 ingress:
-                  remoteGenerated: Anywhere
+                  - remoteNamespace: gitlab
             - name: ACID_PG_CLUSTER_NETWORKING
               description: "Allow connectivity to the acid pg cluster for testing (see tests/ folder)"
               path: custom

--- a/chart/templates/uds-package-postgres.yaml
+++ b/chart/templates/uds-package-postgres.yaml
@@ -29,7 +29,7 @@ spec:
 
       - direction: Ingress
         selector:
-          app.kubernetes.io/name: postgres-operator
+          cluster-name: pg-cluster
         remoteNamespace: {{ .Release.Namespace }}
         remoteSelector:
           app.kubernetes.io/name: postgres-operator

--- a/tests/postgres/postgres-minimal.yaml
+++ b/tests/postgres/postgres-minimal.yaml
@@ -22,4 +22,4 @@ spec:
   databases:
     mydb: myuser
   postgresql:
-    version: "13"
+    version: "14"


### PR DESCRIPTION
## Description

The netpol selector for ingress to the default pg cluster is incorrect - this can be worked around with remoteGenerated Anywhere but more scoped netpols will fail.

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
