### PR TITLE
feat: tls certificate from secret

### DIFF
--- a/chart/templates/postgres-minimal.yaml
+++ b/chart/templates/postgres-minimal.yaml
@@ -32,6 +32,15 @@ spec:
     - {{ . | toYaml | nindent 6 }}
     {{- end }}
   {{- end }}
+  {{- with .Values.postgresql.tls }}
+  {{- if .secretName }}
+  tls:
+    secretName: {{ .secretName }}
+    {{- if .caSecretName }}
+    caSecretName: {{ .caSecretName }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
   sidecars:
     - name: "exporter"
       image: {{ .Values.metrics.image | quote }}

--- a/chart/templates/postgres-minimal.yaml
+++ b/chart/templates/postgres-minimal.yaml
@@ -32,14 +32,9 @@ spec:
     - {{ . | toYaml | nindent 6 }}
     {{- end }}
   {{- end }}
-  {{- with .Values.postgresql.tls }}
-  {{- if .secretName }}
+  {{- if .Values.postgresql.tls }}
   tls:
-    secretName: {{ .secretName }}
-    {{- if .caSecretName }}
-    caSecretName: {{ .caSecretName }}
-    {{- end }}
-  {{- end }}
+    {{- toYaml .Values.postgresql.tls | nindent 4 }}
   {{- end }}
   sidecars:
     - name: "exporter"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,7 @@ Postgres Operator is configured through [`acid.zalan.do/v1` `Postgresql` custom 
 - `postgresql.ingress`: A list of ingress entries to create for this cluster (follows the [custom networking definition](https://github.com/defenseunicorns/uds-software-factory/blob/main/docs/networking.md) except for `direction` which is always `Ingress` and `selector` which is always `cluster-name: pg-cluster`)
 - `postgresql.resources`: A Kubernetes Pod resource specification to define requests and limits
 - `postgresql.additionalVolumes`: A list of additional volumes to map into the Postgres container if needed (see below)
-- `postgresql.tls.secretName`: Name of the secret containing the TLS cert for Postgres to use (optional)
-- `postgresql.tls.caSecretName`: Name of the secret containing the TLS CA cert for Postgres to use (optional, only takes effect if `postgresql.tls.secretName` is set)
+- `postgresql.tls`: TLS configuration for the Postgres cluster to use (follows the [`tls` section of the Zalando Postgres CR](https://github.com/zalando/postgres-operator/blob/master/docs/reference/cluster_manifest.md#custom-tls-certificates))
 
 ## Postgres HugePages
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,8 @@ Postgres Operator is configured through [`acid.zalan.do/v1` `Postgresql` custom 
 - `postgresql.ingress`: A list of ingress entries to create for this cluster (follows the [custom networking definition](https://github.com/defenseunicorns/uds-software-factory/blob/main/docs/networking.md) except for `direction` which is always `Ingress` and `selector` which is always `cluster-name: pg-cluster`)
 - `postgresql.resources`: A Kubernetes Pod resource specification to define requests and limits
 - `postgresql.additionalVolumes`: A list of additional volumes to map into the Postgres container if needed (see below)
+- `postgresql.tls.secretName`: Name of the secret containing the TLS cert for Postgres to use (optional)
+- `postgresql.tls.caSecretName`: Name of the secret containing the TLS CA cert for Postgres to use (optional, only takes effect if `postgresql.tls.secretName` is set)
 
 ## Postgres HugePages
 


### PR DESCRIPTION
## Description
Allows for Postgres to use a custom user-specified certificate from a secret in postgres-minimal deployment. For example:
```yaml
postgresql:
  enabled: true # Set to false to not create the PostgreSQL resource
  teamId: "uds"
  volume:
    size: "10Gi"
  numberOfInstances: 2
  users:
    client.client: [] # database owner
  databases:
    clientdb: client.client
  version: "13"
  ingress:
    remoteGenerated: Anywhere
  tls:
    secretName: my-custom-postgres-cert
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
