### PR TITLE
feat: update templating to allow passing additional postgresql parameters via values overrides

### DIFF
--- a/chart/templates/postgres-minimal.yaml
+++ b/chart/templates/postgres-minimal.yaml
@@ -21,8 +21,12 @@ spec:
   patroni:
     {{- toYaml .Values.postgresql.patroni | nindent 4 }}
   postgresql:
+    {{- if ne (len .Values.postgresql.parameters) 0 }}
     parameters:
-      password_encryption: {{ .Values.postgresql.password_encryption | quote }}
+      {{- range .Values.postgresql.parameters }}
+      {{- .name | nindent 6 }}: {{ .value | quote }}
+      {{- end }}
+    {{- end }}
     version: {{ .Values.postgresql.version | quote }}
   resources:
     {{- toYaml .Values.postgresql.resources | nindent 4 }}

--- a/chart/templates/postgres-minimal.yaml
+++ b/chart/templates/postgres-minimal.yaml
@@ -21,12 +21,22 @@ spec:
   patroni:
     {{- toYaml .Values.postgresql.patroni | nindent 4 }}
   postgresql:
-    {{- if ne (len .Values.postgresql.parameters) 0 }}
-    parameters:
-      {{- range .Values.postgresql.parameters }}
-      {{- .name | nindent 6 }}: {{ .value | quote }}
+    {{- $defaultPasswordEncryptionName := "password_encryption" }}
+    {{- $defaultPasswordEncryptionValue := "scram-sha-256" }}
+    {{- $userParams := .Values.postgresql.parameters | default list }}
+    {{- $hasPasswordEncryption := false }}
+    {{- range $userParams }}
+      {{- if eq .name $defaultPasswordEncryptionName }}
+        {{- $hasPasswordEncryption = true }}
       {{- end }}
     {{- end }}
+    parameters:
+      {{- if not $hasPasswordEncryption }}
+      {{- $defaultPasswordEncryptionName | nindent 6 }}: {{ $defaultPasswordEncryptionValue | quote }}
+      {{- end }}
+      {{- range $userParams }}
+      {{- .name | nindent 6 }}: {{ .value | quote }}
+      {{- end }}
     version: {{ .Values.postgresql.version | quote }}
   resources:
     {{- toYaml .Values.postgresql.resources | nindent 4 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,9 +3,7 @@
 
 postgresql:
   enabled: false
-  parameters:
-    - name: password_encryption
-      value: scram-sha-256
+  parameters: []
   ingress: []
   resources:
     limits:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,7 +3,9 @@
 
 postgresql:
   enabled: false
-  password_encryption: scram-sha-256
+  parameters:
+    - name: password_encryption
+      value: scram-sha-256
   ingress: []
   resources:
     limits:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,13 @@ Postgres Operator is configured through [`acid.zalan.do/v1` `Postgresql` custom 
 - `postgresql.resources`: A Kubernetes Pod resource specification to define requests and limits
 - `postgresql.additionalVolumes`: A list of additional volumes to map into the Postgres container if needed (see below)
 - `postgresql.tls`: TLS configuration for the Postgres cluster to use (follows the [`tls` section of the Zalando Postgres CR](https://github.com/zalando/postgres-operator/blob/master/docs/reference/cluster_manifest.md#custom-tls-certificates))
+- `postgresql.parameters`: A list of database parameters to set as name/value pairs, if needed, e.g.:
+
+```yaml
+  parameters:
+    - name: password_encryption
+      value: scram-sha-256
+```
 
 ## Postgres HugePages
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,12 +23,14 @@ Postgres Operator is configured through [`acid.zalan.do/v1` `Postgresql` custom 
 - `postgresql.resources`: A Kubernetes Pod resource specification to define requests and limits
 - `postgresql.additionalVolumes`: A list of additional volumes to map into the Postgres container if needed (see below)
 - `postgresql.tls`: TLS configuration for the Postgres cluster to use (follows the [`tls` section of the Zalando Postgres CR](https://github.com/zalando/postgres-operator/blob/master/docs/reference/cluster_manifest.md#custom-tls-certificates))
-- `postgresql.parameters`: A list of database parameters to set as name/value pairs, if needed, e.g.:
+- `postgresql.parameters`: A list of database parameters to set as name/value pairs, if needed. `password_encryption` parameter defaults to `scram-sha-256` unless specifically overridden via parameters list.
 
 ```yaml
   parameters:
-    - name: password_encryption
-      value: scram-sha-256
+    - name: max_slot_wal_keep_size
+      value: 1GB
+    - name: <name>
+      value: <value>
 ```
 
 ## Postgres HugePages


### PR DESCRIPTION
Update templating to allow passing additional postgresql parameters via values overrides

## Description

Previously, only a single hard-coded parameter was configurable via values overrides: `password_encryption`.

This updates the `postgresql` CRD template to support passing database parameters as a list of name/value pairs to be more flexible, while maintaining the default value for `password_encryption` unless explicitly overridden.

Default value:

```yaml
postgresql:
  parameters: []
```

Templated result snippet with `postgresql.enabled=true`:

```yaml
spec:
  postgresql:
    parameters:
      password_encryption: "scram-sha-256"
```

Example passing an additional parameter:

```yaml
postgresql:
  parameters:
    - name: max_slot_wal_keep_size
      value: 1GB
```
Yields:
```yaml
spec:
  postgresql:
    parameters:
      password_encryption: "scram-sha-256"
      max_slot_wal_keep_size: "1GB"
```

Example with explicit override for `password_encryption`:

```yaml
postgresql:
  parameters:
    - name: password_encryption
      value: md5
```
Yields:
```yaml
spec:
  postgresql:
    parameters:
      password_encryption: "md5"
```

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
