### PR TITLE
feat: add job to expose extensions

### DIFF
--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -32,6 +32,8 @@ packages:
                   gitlabdb: gitlab.gitlab
                   mattermostdb: mattermost.mattermost
                   sonarqubedb: sonarqube.sonarqube
+                extensions:
+                  gitlabdb: ["hstore"]
                 version: "14"
                 ingress:
                   - remoteNamespace: gitlab

--- a/chart/templates/extension-job.yaml
+++ b/chart/templates/extension-job.yaml
@@ -8,6 +8,7 @@ metadata:
   name: enable-extensions
   namespace: postgres
 spec:
+  ttlSecondsAfterFinished: 30
   template:
     spec:
       restartPolicy: OnFailure

--- a/chart/templates/extension-job.yaml
+++ b/chart/templates/extension-job.yaml
@@ -1,0 +1,55 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+{{- if and .Values.postgresql.enabled .Values.postgresql.extensions }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: enable-extensions
+  namespace: postgres
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: extension-setup
+          image: {{ .Values.job.image | quote }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              # Wait for each database to be ready
+              for db in {{- range $db, $_ := .Values.postgresql.extensions }} {{ $db }} {{- end }}; do
+                echo "Waiting for database $db to become available..."
+                until PGPASSWORD=$PGPASSWORD psql \
+                  -h pg-cluster.postgres.svc.cluster.local \
+                  -U "$PGUSERNAME" \
+                  -d "$db" \
+                  -c '\q' 2>/dev/null; do
+                  sleep 3
+                done
+              done
+
+              # Install extensions per database
+              {{- range $db, $exts := .Values.postgresql.extensions }}
+              echo "Installing extensions in database: {{ $db }}"
+              for ext in {{- range $exts }} {{ . }} {{- end }}; do
+                echo "Creating extension: $ext"
+                PGPASSWORD=$PGPASSWORD psql \
+                  -h pg-cluster.postgres.svc.cluster.local \
+                  -U "$PGUSERNAME" \
+                  -d "{{ $db }}" \
+                  -c "CREATE EXTENSION IF NOT EXISTS $ext;"
+              done
+              {{- end }}
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres.pg-cluster.credentials.postgresql.acid.zalan.do
+                  key: password
+            - name: PGUSERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: postgres.pg-cluster.credentials.postgresql.acid.zalan.do
+                  key: username
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,6 +25,8 @@ postgresql:
 #   databases:
 #     mydb: mynamespace.myuser
 #     yourdb: yournamespace.youruser
+#   extensions:
+#     mydb: ["postgis","hstore"] # database extensions
 #   version: "14"
 #   ingress:
 #     - remoteGenerated: Anywhere

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=ghcr.io/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.14.0-uds.3
+    version: 1.14.0-uds.4
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.14.0-uds.3
+    version: 1.14.0-uds.4
   - name: unicorn
     # renovate-uds: datasource=docker depName=cgr.dev/du-uds-defenseunicorns/postgres-operator-fips
-    version: 1.14.0-uds.3
+    version: 1.14.0-uds.4

--- a/values/registry1-config-values.yaml
+++ b/values/registry1-config-values.yaml
@@ -3,3 +3,6 @@
 
 metrics:
   image: "registry1.dso.mil/ironbank/opensource/prometheus/postgres-exporter:v0.17.1"
+
+job: 
+  image: "ghcr.io/zalando/spilo-17:4.0-p2"

--- a/values/registry1-config-values.yaml
+++ b/values/registry1-config-values.yaml
@@ -4,5 +4,5 @@
 metrics:
   image: "registry1.dso.mil/ironbank/opensource/prometheus/postgres-exporter:v0.17.1"
 
-job: 
+job:
   image: "ghcr.io/zalando/spilo-17:4.0-p2"

--- a/values/unicorn-config-values.yaml
+++ b/values/unicorn-config-values.yaml
@@ -4,5 +4,5 @@
 metrics:
   image: "cgr.dev/du-uds-defenseunicorns/prometheus-postgres-exporter-fips:0.17.1"
 
-job: 
+job:
   image: "ghcr.io/zalando/spilo-17:4.0-p2"

--- a/values/unicorn-config-values.yaml
+++ b/values/unicorn-config-values.yaml
@@ -3,3 +3,6 @@
 
 metrics:
   image: "cgr.dev/du-uds-defenseunicorns/prometheus-postgres-exporter-fips:0.17.1"
+
+job: 
+  image: "ghcr.io/zalando/spilo-17:4.0-p2"

--- a/values/upstream-config-values.yaml
+++ b/values/upstream-config-values.yaml
@@ -4,5 +4,5 @@
 metrics:
   image: "quay.io/prometheuscommunity/postgres-exporter:v0.17.1"
 
-job: 
+job:
   image: "ghcr.io/zalando/spilo-17:4.0-p2"

--- a/values/upstream-config-values.yaml
+++ b/values/upstream-config-values.yaml
@@ -3,3 +3,6 @@
 
 metrics:
   image: "quay.io/prometheuscommunity/postgres-exporter:v0.17.1"
+
+job: 
+  image: "ghcr.io/zalando/spilo-17:4.0-p2"


### PR DESCRIPTION
## Description

- Create new job to allow postgres extensions to be enabled via overrides.
- I tested the below configuration. I exec'd into the postgres pods after the job ran, and verified that each specified extension was created for the specified database

```yaml
    extensions:
      gitlabdb: ["postgis"]
      mattermostdb: ["hstore"]
      sonarqubedb: ["citext", "tablefunc"]
```

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
