### PR TITLE
chore!: enforce `scram-sha-256` in postgres parameters and `pg_hba.conf`

### DIFF
--- a/chart/templates/postgres-minimal.yaml
+++ b/chart/templates/postgres-minimal.yaml
@@ -18,24 +18,42 @@ spec:
     {{- toYaml .Values.postgresql.users | nindent 4 }} # database owner
   databases:
     {{- toYaml .Values.postgresql.databases | nindent 4 }}
-  patroni:
-    {{- toYaml .Values.postgresql.patroni | nindent 4 }}
-  postgresql:
-    {{- $defaultPasswordEncryptionName := "password_encryption" }}
-    {{- $defaultPasswordEncryptionValue := "scram-sha-256" }}
-    {{- $userParams := .Values.postgresql.parameters | default list }}
-    {{- $hasPasswordEncryption := false }}
-    {{- range $userParams }}
-      {{- if eq .name $defaultPasswordEncryptionName }}
-        {{- $hasPasswordEncryption = true }}
-      {{- end }}
+
+  {{- $passwordEncryption := "scram-sha-256" }}
+  {{- range .Values.postgresql.parameters | default list }}
+    {{- if eq .name "password_encryption" }}
+      {{- $passwordEncryption = .value }}
     {{- end }}
+  {{- end }}
+  patroni:
+    pg_hba:
+    {{- $defaultPgHba := list 
+        "local   all             all                                     trust"
+        "hostssl all             +zalandos            127.0.0.1/32       pam"
+        (printf "host    all             all                  127.0.0.1/32       %s" $passwordEncryption)
+        "hostssl all             +zalandos            ::1/128            pam"
+        (printf "host    all             all                  ::1/128            %s" $passwordEncryption)
+        "local   replication     standby                                 trust"
+        (printf "hostssl replication     standby all                             %s" $passwordEncryption)
+        "hostnossl all           all                  all                reject"
+        "hostssl all             +zalandos            all                pam"
+        (printf "hostssl all             all                  all                %s" $passwordEncryption)
+    }}
+    {{- if and (hasKey .Values.postgresql "patroni") (hasKey .Values.postgresql.patroni "pg_hba") }}
+      {{- toYaml .Values.postgresql.patroni.pg_hba | nindent 6 }}
+    {{- else }}
+      {{- toYaml $defaultPgHba | nindent 6 }}
+    {{- end }}
+    {{- with (omit (.Values.postgresql.patroni | default dict) "pg_hba") }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  postgresql:
     parameters:
-      {{- if not $hasPasswordEncryption }}
-      {{- $defaultPasswordEncryptionName | nindent 6 }}: {{ $defaultPasswordEncryptionValue | quote }}
-      {{- end }}
-      {{- range $userParams }}
-      {{- .name | nindent 6 }}: {{ .value | quote }}
+      password_encryption: {{ $passwordEncryption | quote }}
+      {{- range .Values.postgresql.parameters | default list }}
+        {{- if ne .name "password_encryption" }}
+        {{ .name }}: {{ .value | quote }}
+        {{- end }}
       {{- end }}
     version: {{ .Values.postgresql.version | quote }}
   resources:

--- a/chart/templates/postgres-minimal.yaml
+++ b/chart/templates/postgres-minimal.yaml
@@ -18,26 +18,19 @@ spec:
     {{- toYaml .Values.postgresql.users | nindent 4 }} # database owner
   databases:
     {{- toYaml .Values.postgresql.databases | nindent 4 }}
-
-  {{- $passwordEncryption := "scram-sha-256" }}
-  {{- range .Values.postgresql.parameters | default list }}
-    {{- if eq .name "password_encryption" }}
-      {{- $passwordEncryption = .value }}
-    {{- end }}
-  {{- end }}
   patroni:
     pg_hba:
     {{- $defaultPgHba := list 
         "local   all             all                                     trust"
         "hostssl all             +zalandos            127.0.0.1/32       pam"
-        (printf "host    all             all                  127.0.0.1/32       %s" $passwordEncryption)
+        "host    all             all                  127.0.0.1/32       scram-sha-256"
         "hostssl all             +zalandos            ::1/128            pam"
-        (printf "host    all             all                  ::1/128            %s" $passwordEncryption)
+        "host    all             all                  ::1/128            scram-sha-256"
         "local   replication     standby                                 trust"
-        (printf "hostssl replication     standby all                             %s" $passwordEncryption)
+        "hostssl replication     standby all                             scram-sha-256"
         "hostnossl all           all                  all                reject"
         "hostssl all             +zalandos            all                pam"
-        (printf "hostssl all             all                  all                %s" $passwordEncryption)
+        "hostssl all             all                  all                scram-sha-256"
     }}
     {{- if and (hasKey .Values.postgresql "patroni") (hasKey .Values.postgresql.patroni "pg_hba") }}
       {{- toYaml .Values.postgresql.patroni.pg_hba | nindent 6 }}
@@ -49,7 +42,7 @@ spec:
     {{- end }}
   postgresql:
     parameters:
-      password_encryption: {{ $passwordEncryption | quote }}
+      password_encryption: scram-sha-256
       {{- range .Values.postgresql.parameters | default list }}
         {{- if ne .name "password_encryption" }}
         {{ .name }}: {{ .value | quote }}

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=ghcr.io/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.14.0-uds.7
+    version: 1.14.0-uds.8
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.14.0-uds.7
+    version: 1.14.0-uds.8
   - name: unicorn
     # renovate-uds: datasource=docker depName=cgr.dev/du-uds-defenseunicorns/postgres-operator-fips
-    version: 1.14.0-uds.7
+    version: 1.14.0-uds.8


### PR DESCRIPTION
## Description

This sets `scram-sha-256` to be the only mechanism that is supported in the `pg_hba.conf` and the postgres `parameters`.

> [!CAUTION]
> :warning: **BREAKING CHANGE** this change will force `scram-sha-256` `password_encryption` to better test against a FIPS-valid configuration for postgres in apps - installations should not be using `md5` since it is not a valid FIPS 140-3 algorithm but if they are they will need to rotate the user passwords.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
