### PR TITLE
test: add test for pgbouncer configuration

### DIFF
--- a/chart/templates/postgres-minimal.yaml
+++ b/chart/templates/postgres-minimal.yaml
@@ -97,4 +97,5 @@ spec:
             secretKeyRef:
               name: postgres.pg-cluster.credentials.postgresql.acid.zalan.do
               key: password
+  enableConnectionPooler: false
 {{- end }}

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=ghcr.io/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.15.1-uds.1
+    version: 1.15.1-uds.2
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.15.0-uds.1
+    version: 1.15.0-uds.2
   - name: unicorn
     # renovate-uds: datasource=docker depName=quay.io/rfcurated/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.15.0-uds.1
+    version: 1.15.0-uds.2

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -6,6 +6,7 @@ tasks:
     actions:
       - task: health-check
       - task: create-dbs
+      - task: configure-pgbouncer
 
   - name: create-dbs
     actions:
@@ -23,3 +24,28 @@ tasks:
             name: app.kubernetes.io/name=postgres-operator
             namespace: postgres-operator
             condition: Ready
+
+  - name: configure-pgbouncer
+    description: Prove pgbouncer deployment isn't working, then configure and verify.
+    actions:
+      - cmd: ./zarf tools kubectl get postgresql -n postgres -o jsonpath='{.items[0].spec.enableConnectionPooler}'
+        setVariables:
+          - name: POOLER_ENABLED
+      - description: Check status and apply fix
+        cmd: |
+          if [[ "${POOLER_ENABLED}" == "false" ]]; then
+            echo "PgBouncer was not deployed." && exit 0
+          fi
+          CLUSTER_NAME=$(./zarf tools kubectl get postgresql -n postgres -o jsonpath='{.items[0].metadata.name}')
+          if ./zarf tools kubectl rollout status deployment/"$CLUSTER_NAME-pooler" -n postgres --timeout=5s; then
+            echo "PgBouncer already healthy!" && exit 0
+          else
+            echo "Get logs of unhealthy deployment:"
+            ./zarf tools kubectl logs -n postgres deployment/"$CLUSTER_NAME-pooler"
+          fi
+          echo "Configuring connection-pooler"
+          ./zarf tools wait-for deployment "$CLUSTER_NAME-pooler" exists -n postgres
+          ./zarf tools kubectl set env -n postgres deployment "$CLUSTER_NAME-pooler" DATABASES_HOST="$CLUSTER_NAME" PGBOUNCER_LISTEN_PORT=5432
+          ./zarf tools kubectl patch deployment "$CLUSTER_NAME-pooler" -n postgres -p \
+            '{"spec":{"template":{"metadata":{"labels":{"uds/user":"70","uds/group":"70","uds/fsgroup":"70"}}}}}'
+          ./zarf tools wait-for deployment "${CLUSTER_NAME}-pooler" available -n postgres --timeout=120s

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -33,7 +33,7 @@ tasks:
           - name: POOLER_ENABLED
       - description: Check status and apply fix
         cmd: |
-          if [[ "${POOLER_ENABLED}" == "false" ]]; then
+          if [ "${POOLER_ENABLED}" == "false" ]; then
             echo "PgBouncer was not deployed." && exit 0
           fi
           CLUSTER_NAME=$(./zarf tools kubectl get postgresql -n postgres -o jsonpath='{.items[0].metadata.name}')

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -26,17 +26,17 @@ tasks:
             condition: Ready
 
   - name: configure-pgbouncer
-    description: Prove pgbouncer deployment isn't working, then configure and verify.
+    description: "Prove pgbouncer deployment isn't working, then configure and verify."
     actions:
-      - cmd: ./zarf tools kubectl get postgresql -n postgres -o jsonpath='{.items[0].spec.enableConnectionPooler}'
+      - cmd: ./zarf tools kubectl get postgresql -n postgres -o jsonpath="{.items[0].spec.enableConnectionPooler}"
         setVariables:
           - name: POOLER_ENABLED
       - description: Check status and apply fix
         cmd: |
-          if [ "${POOLER_ENABLED}" == "false" ]; then
+          if [ "${POOLER_ENABLED}" = "false" ]; then
             echo "PgBouncer was not deployed." && exit 0
           fi
-          CLUSTER_NAME=$(./zarf tools kubectl get postgresql -n postgres -o jsonpath='{.items[0].metadata.name}')
+          CLUSTER_NAME=$(./zarf tools kubectl get postgresql -n postgres -o jsonpath="{.items[0].metadata.name}")
           if ./zarf tools kubectl rollout status deployment/"$CLUSTER_NAME-pooler" -n postgres --timeout=5s; then
             echo "PgBouncer already healthy!" && exit 0
           else
@@ -47,5 +47,5 @@ tasks:
           ./zarf tools wait-for deployment "$CLUSTER_NAME-pooler" exists -n postgres
           ./zarf tools kubectl set env -n postgres deployment "$CLUSTER_NAME-pooler" DATABASES_HOST="$CLUSTER_NAME" PGBOUNCER_LISTEN_PORT=5432
           ./zarf tools kubectl patch deployment "$CLUSTER_NAME-pooler" -n postgres -p \
-            '{"spec":{"template":{"metadata":{"labels":{"uds/user":"70","uds/group":"70","uds/fsgroup":"70"}}}}}'
+            "\{"spec":\{"template":\{"metadata":\{"labels":\{"uds/user":"70","uds/group":"70","uds/fsgroup":"70"\}\}\}\}\}"
           ./zarf tools wait-for deployment "${CLUSTER_NAME}-pooler" available -n postgres --timeout=120s


### PR DESCRIPTION
## Description

The pgbouncer image provided by RapidFort is not configured to work with the upstream chart. This PR adds a test that proves pgbouncer does not deploy correctly, then it sets the correct environment variables and security context for pgbouncer to operate.

The `enableConnectPooler` var is also added to simplify deploying PGBouncer. 

To reproduce the error and run the test:
1. Set `spec.enableConnectionPooler` to true in `postgres-minimal.yaml`
2. Deploy the unicorn flavor 
3. `uds run -f tasks/test.yaml configure-pgbouncer`

## Related Issue

Relates to 
https://github.com/defenseunicorns/mission-success/issues/586
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
