### PR TITLE
chore: add maintainers to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # This repository is owned by the UDS Foundry Team
-* @uds-packages/uds-foundry @uds-packages/federal-swf
+* @uds-packages/maintainers @uds-packages/uds-foundry @uds-packages/federal-swf
 
 # Additional privileged files
 /CODEOWNERS @jeff-mccoy @daveworth


### PR DESCRIPTION
## Description

Add @uds-packages/maintainers to CODEOWNERS for [foundry-owned packages](https://www.notion.so/defense-unicorns/Projects-UDS-Foundry-Supports-26ae512f24fc80e18cdbe7c7b68cc979) for consistency.

## Related Issue

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
