### PR TITLE
fix: fix templating for helmv4 and bump releaser

### DIFF
--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -28,13 +28,19 @@ spec:
       # Custom rules for other scenarios (such as connecting to a non-default pg cluster)
       {{- range .Values.additionalNetworkAllow }}
       - direction: {{ .direction }}
+        {{- if .selector}}
         selector:
           {{ .selector | toYaml | nindent 10 }}
+        {{- end }}
         {{- if not .remoteGenerated }}
         remoteNamespace: {{ .remoteNamespace }}
+        {{- if .remoteSelector }}
         remoteSelector:
           {{ .remoteSelector | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if .port }}
         port: {{ .port }}
+        {{- end }}
         {{- else }}
         remoteGenerated: {{ .remoteGenerated }}
         {{- end }}

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=ghcr.io/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.15.1-uds.1
+    version: 1.15.1-uds.2
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.15.0-uds.10
+    version: 1.15.0-uds.11
   - name: unicorn
     # renovate-uds: datasource=docker depName=quay.io/rfcurated/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.15.0-uds.11
+    version: 1.15.0-uds.12

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -7,7 +7,7 @@ flavors:
     version: 1.15.1-uds.2
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.15.0-uds.11
+    version: 1.15.0-uds.12
   - name: unicorn
     # renovate-uds: datasource=docker depName=quay.io/rfcurated/zalando/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.15.0-uds.12
+    version: 1.15.0-uds.13


### PR DESCRIPTION
## Description

fix templating for helmv4 and bump releaser

## Related Issue

Relates to # https://linear.app/defense-unicorns/issue/FDRY-78/standardize-helm-templates-to-prevent-dangling-key-validation-errors

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
